### PR TITLE
fix get_avail_memory for cgroups v1/v2 (AB#24354)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,6 +15,6 @@ jobs:
         run: rpmlint Lmod-config.spec
 
       - name: Run luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1
         with:
           args: -g .

--- a/Lmod-config.spec
+++ b/Lmod-config.spec
@@ -1,6 +1,6 @@
 Summary: Sitepackage and other config files for Lmod
 Name: Lmod-config
-Version: 1.9
+Version: 1.10
 Release: 1
 License: GPL
 Group: Applications/System
@@ -40,6 +40,8 @@ exit 0
 %{_libexecdir}/lmod/run_lmod_cache.py
 
 %changelog
+* Fri Jan 17 2025 Alex Domingo <alex.domingo.toro@vub.be>
+- Fix get_avail_memory for cgroups v1/v2
 * Mon Jan 06 2025 Cintia Willemyns <cintia.willemyns@vub.be>
 - Hide modules older than module_age 6, instead of 5
 * Wed Sep 25 2024 Samuel Moors <samuel.moors@vub.be>

--- a/SitePackage.lua
+++ b/SitePackage.lua
@@ -266,7 +266,7 @@ local function get_avail_memory()
     end
 
     local cgroup = nil
-    local memory_filepath = nil
+    local memory_filepath
     -- if it's one line: cgroupv2
     if #lines == 1 then
         cgroup = lines[1]:match("^[0-9]+::(.*)$")


### PR DESCRIPTION
fixes #AD24354